### PR TITLE
fix: prevent zero amount send

### DIFF
--- a/src/contracts/hop/FraxtalHop.sol
+++ b/src/contracts/hop/FraxtalHop.sol
@@ -37,6 +37,7 @@ contract FraxtalHop is Ownable2Step, IOAppComposer {
     error NotEndpoint();
     error InvalidSourceChain();
     error InvalidSourceHop();
+    error ZeroAmountSend();
 
     constructor() Ownable(msg.sender) {}
 
@@ -144,11 +145,13 @@ contract FraxtalHop is Ownable2Step, IOAppComposer {
         bytes32 _to,
         uint256 _amountLD
     ) public view returns (MessagingFee memory fee) {
+        uint256 _minAmountLD = removeDust(oft, _amountLD);
+        if (_minAmountLD == 0) revert ZeroAmountSend();
         SendParam memory sendParam = _generateSendParam({
             _dstEid: _dstEid,
             _to: _to,
             _amountLD: _amountLD,
-            _minAmountLD: removeDust(oft, _amountLD)
+            _minAmountLD: _minAmountLD
         });
         fee = IOFT(oft).quoteSend(sendParam, false);
     }

--- a/src/contracts/hop/FraxtalMintRedeemHop.sol
+++ b/src/contracts/hop/FraxtalMintRedeemHop.sol
@@ -42,6 +42,7 @@ contract FraxtalMintRedeemHop is Ownable2Step, IOAppComposer {
     error NotEndpoint();
     error InvalidSourceChain();
     error InvalidSourceHop();
+    error ZeroAmountSend();
 
     constructor() Ownable(msg.sender) {}
 
@@ -126,11 +127,13 @@ contract FraxtalMintRedeemHop is Ownable2Step, IOAppComposer {
 
     function _send(address _oft, uint32 _dstEid, bytes32 _to, uint256 _amountLD) internal {
         // generate arguments
+        uint256 _minAmountLD = removeDust(_oft, _amountLD);
+        if (_minAmountLD == 0) revert ZeroAmountSend();
         SendParam memory sendParam = _generateSendParam({
             _dstEid: _dstEid,
             _to: _to,
             _amountLD: _amountLD,
-            _minAmountLD: removeDust(_oft, _amountLD)
+            _minAmountLD: _minAmountLD
         });
         MessagingFee memory fee = IOFT(_oft).quoteSend(sendParam, false);
         // Send the oft

--- a/src/contracts/hop/RemoteHop.sol
+++ b/src/contracts/hop/RemoteHop.sol
@@ -42,6 +42,7 @@ contract RemoteHop is Ownable2Step {
     error HopPaused();
     error NotEndpoint();
     error InsufficientFee();
+    error ZeroAmountSend();
 
     constructor(
         bytes32 _fraxtalHop,
@@ -96,6 +97,7 @@ contract RemoteHop is Ownable2Step {
     function sendOFT(address _oft, uint32 _dstEid, bytes32 _to, uint256 _amountLD) external payable {
         if (paused) revert HopPaused();
         _amountLD = removeDust(_oft, _amountLD);
+        if (_amountLD == 0) revert ZeroAmountSend();
         SafeERC20.safeTransferFrom(IERC20(IOFT(_oft).token()), msg.sender, address(this), _amountLD);
         if (_dstEid == 30255) {
             _sendToFraxtal(_oft, _to, _amountLD);

--- a/src/contracts/hop/RemoteMintRedeemHop.sol
+++ b/src/contracts/hop/RemoteMintRedeemHop.sol
@@ -42,6 +42,7 @@ contract RemoteMintRedeemHop is Ownable2Step {
     error HopPaused();
     error NotEndpoint();
     error InsufficientFee();
+    error ZeroAmountSend();
 
     constructor(
         bytes32 _fraxtalHop,
@@ -94,6 +95,7 @@ contract RemoteMintRedeemHop is Ownable2Step {
     function mintRedeem(address _oft, uint256 _amountLD) external payable {
         if (paused) revert HopPaused();
         _amountLD = removeDust(_oft, _amountLD);
+        if (_amountLD == 0) revert ZeroAmountSend();
         SafeERC20.safeTransferFrom(IERC20(IOFT(_oft).token()), msg.sender, address(this), _amountLD);
         _mintRedeemViaFraxtal(_oft, bytes32(uint256(uint160(msg.sender))), _amountLD);
 


### PR DESCRIPTION
This is a minor fix to prevent sending an OFT amount that, when dust is removed, is rounded down to zero.