### PR TITLE
fix: only approved ofts

### DIFF
--- a/src/contracts/hop/FraxtalHop.sol
+++ b/src/contracts/hop/FraxtalHop.sol
@@ -25,6 +25,13 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 contract FraxtalHop is Ownable2Step, IOAppComposer {
     address public constant ENDPOINT = 0x1a44076050125825900e736c501f859c50fE728c;
 
+    address public constant frxUsdLockbox = 0x96A394058E2b84A89bac9667B19661Ed003cF5D4;
+    address public constant sfrxUsdLockbox = 0x88Aa7854D3b2dAA5e37E7Ce73A1F39669623a361;
+    address public constant frxEthLockbox = 0x9aBFE1F8a999B0011ecD6116649AEe8D575F5604;
+    address public constant sfrxEthLockbox = 0x999dfAbe3b1cc2EF66eB032Eea42FeA329bBa168;
+    address public constant fxsLockbox = 0xd86fBBd0c8715d2C1f40e451e5C3514e65E7576A;
+    address public constant fpiLockbox = 0x75c38D46001b0F8108c4136216bd2694982C20FC;
+
     bool public paused = false;
     mapping(uint32 => bytes32) public remoteHop;
     mapping(bytes32 => bool) public messageProcessed;
@@ -32,7 +39,7 @@ contract FraxtalHop is Ownable2Step, IOAppComposer {
     event Hop(address oft, uint32 indexed srcEid, uint32 indexed dstEid, bytes32 indexed recipient, uint256 amount);
     event MessageHash(address oft, uint32 indexed srcEid, uint64 indexed nonce, bytes32 indexed composeFrom);
 
-    error InvalidOApp();
+    error InvalidOFT();
     error HopPaused();
     error NotEndpoint();
     error InvalidSourceChain();
@@ -82,6 +89,17 @@ contract FraxtalHop is Ownable2Step, IOAppComposer {
     ) external payable override {
         if (msg.sender != ENDPOINT) revert NotEndpoint();
         if (paused) revert HopPaused();
+        if (
+            _oft != frxUsdLockbox &&
+            _oft != sfrxUsdLockbox &&
+            _oft != frxEthLockbox &&
+            _oft != sfrxEthLockbox &&
+            _oft != fxsLockbox &&
+            _oft != fpiLockbox
+        ) {
+            revert InvalidOFT();
+        }
+
         uint32 srcEid = OFTComposeMsgCodec.srcEid(_message);
         {
             bytes32 composeFrom = OFTComposeMsgCodec.composeFrom(_message);

--- a/src/contracts/hop/FraxtalMintRedeemHop.sol
+++ b/src/contracts/hop/FraxtalMintRedeemHop.sol
@@ -26,8 +26,8 @@ import { IFraxtalERC4626MintRedeemer } from "src/contracts/interfaces/IFraxtalER
 contract FraxtalMintRedeemHop is Ownable2Step, IOAppComposer {
     IFraxtalERC4626MintRedeemer public constant fraxtalERC4626MintRedeemer =
         IFraxtalERC4626MintRedeemer(0xBFc4D34Db83553725eC6c768da71D2D9c1456B55);
-    IOFT public constant frxUSDOAPP = IOFT(0x96A394058E2b84A89bac9667B19661Ed003cF5D4);
-    IOFT public constant sfrxUSDOAPP = IOFT(0x88Aa7854D3b2dAA5e37E7Ce73A1F39669623a361);
+    address public constant frxUsdLockbox = 0x96A394058E2b84A89bac9667B19661Ed003cF5D4;
+    address public constant sfrxUsdLockbox = 0x88Aa7854D3b2dAA5e37E7Ce73A1F39669623a361;
     address public constant ENDPOINT = 0x1a44076050125825900e736c501f859c50fE728c;
 
     bool public paused = false;
@@ -37,7 +37,7 @@ contract FraxtalMintRedeemHop is Ownable2Step, IOAppComposer {
     event Hop(address oft, uint32 indexed srcEid, uint32 indexed dstEid, bytes32 indexed recipient, uint256 amount);
     event MessageHash(address oft, uint32 indexed srcEid, uint64 indexed nonce, bytes32 indexed composeFrom);
 
-    error InvalidOApp();
+    error InvalidOFT();
     error HopPaused();
     error NotEndpoint();
     error InvalidSourceChain();
@@ -87,6 +87,8 @@ contract FraxtalMintRedeemHop is Ownable2Step, IOAppComposer {
     ) external payable override {
         if (msg.sender != ENDPOINT) revert NotEndpoint();
         if (paused) revert HopPaused();
+        if (_oft != frxUsdLockbox && _oft != sfrxUsdLockbox) revert InvalidOFT();
+
         uint32 srcEid = OFTComposeMsgCodec.srcEid(_message);
         {
             bytes32 composeFrom = OFTComposeMsgCodec.composeFrom(_message);
@@ -107,14 +109,14 @@ contract FraxtalMintRedeemHop is Ownable2Step, IOAppComposer {
         // Extract the composed message from the delivered message using the MsgCodec
         (bytes32 recipient, uint32 _dstEid) = abi.decode(OFTComposeMsgCodec.composeMsg(_message), (bytes32, uint32));
         uint256 amount = OFTComposeMsgCodec.amountLD(_message);
-        if (_oft == address(frxUSDOAPP)) {
-            IERC20(frxUSDOAPP.token()).approve(address(fraxtalERC4626MintRedeemer), amount);
+        if (_oft == frxUsdLockbox) {
+            IERC20(IOFT(frxUsdLockbox).token()).approve(address(fraxtalERC4626MintRedeemer), amount);
             amount = fraxtalERC4626MintRedeemer.deposit(amount, address(this));
-            _oft = address(sfrxUSDOAPP);
-        } else if (_oft == address(sfrxUSDOAPP)) {
-            IERC20(sfrxUSDOAPP.token()).approve(address(fraxtalERC4626MintRedeemer), amount);
+            _oft = sfrxUsdLockbox;
+        } else if (_oft == sfrxUsdLockbox) {
+            IERC20(IOFT(sfrxUsdLockbox).token()).approve(address(fraxtalERC4626MintRedeemer), amount);
             amount = fraxtalERC4626MintRedeemer.redeem(amount, address(this), address(this));
-            _oft = address(frxUSDOAPP);
+            _oft = frxUsdLockbox;
         } else {
             // Do not revert, but send back the token
         }

--- a/src/contracts/hop/RemoteMintRedeemHop.sol
+++ b/src/contracts/hop/RemoteMintRedeemHop.sol
@@ -35,10 +35,12 @@ contract RemoteMintRedeemHop is Ownable2Step {
     address public immutable DVN;
     address public immutable TREASURY;
     uint32 public immutable EID;
+    address public immutable frxUsdOft;
+    address public immutable sfrxUsdOft;
 
     event MintRedeem(address oft, address indexed sender, uint256 amountLD);
 
-    error InvalidOApp();
+    error InvalidOFT();
     error HopPaused();
     error NotEndpoint();
     error InsufficientFee();
@@ -49,7 +51,9 @@ contract RemoteMintRedeemHop is Ownable2Step {
         address _EXECUTOR,
         address _DVN,
         address _TREASURY,
-        uint32 _EID
+        uint32 _EID,
+        address _frxUsdOft,
+        address _sfrxUsdOft
     ) Ownable(msg.sender) {
         fraxtalHop = _fraxtalHop;
         numDVNs = _numDVNs;
@@ -57,6 +61,8 @@ contract RemoteMintRedeemHop is Ownable2Step {
         DVN = _DVN;
         TREASURY = _TREASURY;
         EID = _EID;
+        frxUsdOft = _frxUsdOft;
+        sfrxUsdOft = _sfrxUsdOft;
     }
 
     // Admin functions
@@ -93,6 +99,8 @@ contract RemoteMintRedeemHop is Ownable2Step {
 
     function mintRedeem(address _oft, uint256 _amountLD) external payable {
         if (paused) revert HopPaused();
+        if (_oft != frxUsdOft && _oft != sfrxUsdOft) revert InvalidOFT();
+
         _amountLD = removeDust(_oft, _amountLD);
         SafeERC20.safeTransferFrom(IERC20(IOFT(_oft).token()), msg.sender, address(this), _amountLD);
         _mintRedeemViaFraxtal(_oft, bytes32(uint256(uint160(msg.sender))), _amountLD);

--- a/src/script/hop/Remote/DeployRemoteHop.sol
+++ b/src/script/hop/Remote/DeployRemoteHop.sol
@@ -1,0 +1,55 @@
+pragma solidity 0.8.23;
+
+import { BaseScript } from "frax-std/BaseScript.sol";
+import { console } from "frax-std/BaseScript.sol";
+import { RemoteHop } from "src/contracts/hop/RemoteHop.sol";
+import { RemoteMintRedeemHop } from "src/contracts/hop/RemoteMintRedeemHop.sol";
+
+abstract contract DeployRemoteHop is BaseScript {
+    address constant FRAXTAL_HOP = 0xEE30e79b54e9a341dcD5621AF1799e2af799b9B0;
+    address constant FRAXTAL_MINTREDEEM_HOP = 0xf8b29272Db8B482459596C60b37BBF0B8F86E892;
+
+    address EXECUTOR;
+    address DVN;
+    address TREASURY;
+    uint32 EID;
+    address frxUsdOft;
+    address sfrxUsdOft;
+    address frxEthOft;
+    address sfrxEthOft;
+    address fxsOft;
+    address fpiOft;
+
+    function run() public broadcaster {
+        RemoteHop.ApprovedOFTs memory approvedOfts = RemoteHop.ApprovedOFTs({
+            frxUsd: frxUsdOft,
+            sfrxUsd: sfrxUsdOft,
+            frxEth: frxEthOft,
+            sfrxEth: sfrxEthOft,
+            fxs: fxsOft,
+            fpi: fpiOft
+        });
+
+        RemoteHop remoteHop = new RemoteHop({
+            _fraxtalHop: bytes32(uint256(uint160(FRAXTAL_HOP))),
+            _numDVNs: 2,
+            _EXECUTOR: EXECUTOR,
+            _DVN: DVN,
+            _TREASURY: TREASURY,
+            _approvedOfts: approvedOfts
+        });
+        console.log("RemoteHop deployed at:", address(remoteHop));
+
+        RemoteMintRedeemHop remoteMintRedeemHop = new RemoteMintRedeemHop({
+            _fraxtalHop: bytes32(uint256(uint160(FRAXTAL_MINTREDEEM_HOP))),
+            _numDVNs: 2,
+            _EXECUTOR: EXECUTOR,
+            _DVN: DVN,
+            _TREASURY: TREASURY,
+            _EID: EID,
+            _frxUsdOft: frxUsdOft,
+            _sfrxUsdOft: sfrxUsdOft
+        });
+        console.log("RemoteMintRedeemHop deployed at:", address(remoteMintRedeemHop));
+    }
+}

--- a/src/script/hop/Remote/DeployRemoteHopArbitrum.sol
+++ b/src/script/hop/Remote/DeployRemoteHopArbitrum.sol
@@ -1,32 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-import { BaseScript } from "frax-std/BaseScript.sol";
-import { console } from "frax-std/BaseScript.sol";
-import { RemoteHop } from "src/contracts/hop/RemoteHop.sol";
-import { RemoteMintRedeemHop } from "src/contracts/hop/RemoteMintRedeemHop.sol";
-import "src/Constants.sol" as Constants;
+import { DeployRemoteHop } from "./DeployRemoteHop.sol";
 
-contract DeployRemoteHopArbitrum is BaseScript {
-    address constant FRAXTAL_HOP = 0xEE30e79b54e9a341dcD5621AF1799e2af799b9B0;
-    address constant FRAXTAL_MINTREDEEM_HOP = 0xf8b29272Db8B482459596C60b37BBF0B8F86E892;
-    address constant EXECUTOR = 0x31CAe3B7fB82d847621859fb1585353c5720660D;
-    address constant DVN = 0x2f55C492897526677C5B68fb199ea31E2c126416;
-    address constant TREASURY = 0x532410B245eB41f24Ed1179BA0f6ffD94738AE70;
-    uint32 constant EID = 30110;
+contract DeployRemoteHopArbitrum is DeployRemoteHop {
+    constructor() {
+        EXECUTOR = 0x31CAe3B7fB82d847621859fb1585353c5720660D;
+        DVN = 0x2f55C492897526677C5B68fb199ea31E2c126416;
+        TREASURY = 0x532410B245eB41f24Ed1179BA0f6ffD94738AE70;
+        EID = 30110;
 
-    function run() public broadcaster {
-        RemoteHop remoteHop = new RemoteHop(bytes32(uint256(uint160(FRAXTAL_HOP))), 2, EXECUTOR, DVN, TREASURY);
-        console.log("RemoteHop deployed at:", address(remoteHop));
-
-        RemoteMintRedeemHop remoteMintRedeemHop = new RemoteMintRedeemHop(
-            bytes32(uint256(uint160(FRAXTAL_MINTREDEEM_HOP))),
-            2,
-            EXECUTOR,
-            DVN,
-            TREASURY,
-            EID
-        );
-        console.log("RemoteMintRedeemHop deployed at:", address(remoteMintRedeemHop));
+        frxUsdOft = 0x80Eede496655FB9047dd39d9f418d5483ED600df;
+        sfrxUsdOft = 0x5Bff88cA1442c2496f7E475E9e7786383Bc070c0;
+        frxEthOft = 0x43eDD7f3831b08FE70B7555ddD373C8bF65a9050;
+        sfrxEthOft = 0x3Ec3849C33291a9eF4c5dB86De593EB4A37fDe45;
+        fxsOft = 0x64445f0aecC51E94aD52d8AC56b7190e764E561a;
+        fpiOft = 0x90581eCa9469D8D7F5D3B60f4715027aDFCf7927;
     }
 }

--- a/src/script/hop/Remote/DeployRemoteHopEthereum.sol
+++ b/src/script/hop/Remote/DeployRemoteHopEthereum.sol
@@ -1,32 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-import { BaseScript } from "frax-std/BaseScript.sol";
-import { console } from "frax-std/BaseScript.sol";
-import { RemoteHop } from "src/contracts/hop/RemoteHop.sol";
-import { RemoteMintRedeemHop } from "src/contracts/hop/RemoteMintRedeemHop.sol";
-import "src/Constants.sol" as Constants;
+import { DeployRemoteHop } from "./DeployRemoteHop.sol";
 
-contract DeployRemoteHopSonic is BaseScript {
-    address constant FRAXTAL_HOP = 0xEE30e79b54e9a341dcD5621AF1799e2af799b9B0;
-    address constant FRAXTAL_MINTREDEEM_HOP = 0xf8b29272Db8B482459596C60b37BBF0B8F86E892;
-    address constant EXECUTOR = 0x173272739Bd7Aa6e4e214714048a9fE699453059;
-    address constant DVN = 0x589dEDbD617e0CBcB916A9223F4d1300c294236b;
-    address constant TREASURY = 0x5ebB3f2feaA15271101a927869B3A56837e73056;
-    uint32 constant EID = 30101;
+contract DeployRemoteHopEthereum is DeployRemoteHop {
+    constructor() {
+        EXECUTOR = 0x173272739Bd7Aa6e4e214714048a9fE699453059;
+        DVN = 0x589dEDbD617e0CBcB916A9223F4d1300c294236b;
+        TREASURY = 0x5ebB3f2feaA15271101a927869B3A56837e73056;
+        EID = 30101;
 
-    function run() public broadcaster {
-        RemoteHop remoteHop = new RemoteHop(bytes32(uint256(uint160(FRAXTAL_HOP))), 2, EXECUTOR, DVN, TREASURY);
-        console.log("RemoteHop deployed at:", address(remoteHop));
-
-        RemoteMintRedeemHop remoteMintRedeemHop = new RemoteMintRedeemHop(
-            bytes32(uint256(uint160(FRAXTAL_MINTREDEEM_HOP))),
-            2,
-            EXECUTOR,
-            DVN,
-            TREASURY,
-            EID
-        );
-        console.log("RemoteMintRedeemHop deployed at:", address(remoteMintRedeemHop));
+        frxUsdOft = 0x566a6442A5A6e9895B9dCA97cC7879D632c6e4B0;
+        sfrxUsdOft = 0x7311CEA93ccf5f4F7b789eE31eBA5D9B9290E126;
+        frxEthOft = 0x1c1649A38f4A3c5A0c4a24070f688C525AB7D6E6;
+        sfrxEthOft = 0xbBc424e58ED38dd911309611ae2d7A23014Bd960;
+        fxsOft = 0xC6F59a4fD50cAc677B51558489E03138Ac1784EC;
+        fpiOft = 0x9033BAD7aA130a2466060A2dA71fAe2219781B4b;
     }
 }

--- a/src/script/hop/Remote/DeployRemoteHopLinea.sol
+++ b/src/script/hop/Remote/DeployRemoteHopLinea.sol
@@ -1,32 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-import { BaseScript } from "frax-std/BaseScript.sol";
-import { console } from "frax-std/BaseScript.sol";
-import { RemoteHop } from "src/contracts/hop/RemoteHop.sol";
-import { RemoteMintRedeemHop } from "src/contracts/hop/RemoteMintRedeemHop.sol";
-import "src/Constants.sol" as Constants;
+import { DeployRemoteHop } from "./DeployRemoteHop.sol";
 
-contract DeployRemoteHopLinea is BaseScript {
-    address constant FRAXTAL_HOP = 0xEE30e79b54e9a341dcD5621AF1799e2af799b9B0;
-    address constant FRAXTAL_MINTREDEEM_HOP = 0xf8b29272Db8B482459596C60b37BBF0B8F86E892;
-    address constant EXECUTOR = 0x0408804C5dcD9796F22558464E6fE5bDdF16A7c7;
-    address constant DVN = 0x129Ee430Cb2Ff2708CCADDBDb408a88Fe4FFd480;
-    address constant TREASURY = 0xf463B0E147D99763136374E6A22a0Ba9bBb9ed09;
-    uint32 constant EID = 30183;
+contract DeployRemoteHopLinea is DeployRemoteHop {
+    constructor() {
+        EXECUTOR = 0x0408804C5dcD9796F22558464E6fE5bDdF16A7c7;
+        DVN = 0x129Ee430Cb2Ff2708CCADDBDb408a88Fe4FFd480;
+        TREASURY = 0xf463B0E147D99763136374E6A22a0Ba9bBb9ed09;
+        EID = 30183;
 
-    function run() public broadcaster {
-        RemoteHop remoteHop = new RemoteHop(bytes32(uint256(uint160(FRAXTAL_HOP))), 2, EXECUTOR, DVN, TREASURY);
-        console.log("RemoteHop deployed at:", address(remoteHop));
-
-        RemoteMintRedeemHop remoteMintRedeemHop = new RemoteMintRedeemHop(
-            bytes32(uint256(uint160(FRAXTAL_MINTREDEEM_HOP))),
-            2,
-            EXECUTOR,
-            DVN,
-            TREASURY,
-            EID
-        );
-        console.log("RemoteMintRedeemHop deployed at:", address(remoteMintRedeemHop));
+        frxUsdOft = 0xC7346783f5e645aa998B106Ef9E7f499528673D8;
+        sfrxUsdOft = 0x592a48c0FB9c7f8BF1701cB0136b90DEa2A5B7B6;
+        frxEthOft = 0xB1aFD04774c02AE84692619448B08BA79F19b1ff;
+        sfrxEthOft = 0x383Eac7CcaA89684b8277cBabC25BCa8b13B7Aa2;
+        fxsOft = 0x5217Ab28ECE654Aab2C68efedb6A22739df6C3D5;
+        fpiOft = 0xDaF72Aa849d3C4FAA8A9c8c99f240Cf33dA02fc4;
     }
 }

--- a/src/script/hop/Remote/DeployRemoteHopSei.sol
+++ b/src/script/hop/Remote/DeployRemoteHopSei.sol
@@ -1,32 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-import { BaseScript } from "frax-std/BaseScript.sol";
-import { console } from "frax-std/BaseScript.sol";
-import { RemoteHop } from "src/contracts/hop/RemoteHop.sol";
-import { RemoteMintRedeemHop } from "src/contracts/hop/RemoteMintRedeemHop.sol";
-import "src/Constants.sol" as Constants;
+import { DeployRemoteHop } from "./DeployRemoteHop.sol";
 
-contract DeployRemoteHopSei is BaseScript {
-    address constant FRAXTAL_HOP = 0xEE30e79b54e9a341dcD5621AF1799e2af799b9B0;
-    address constant FRAXTAL_MINTREDEEM_HOP = 0xf8b29272Db8B482459596C60b37BBF0B8F86E892;
-    address constant EXECUTOR = 0xc097ab8CD7b053326DFe9fB3E3a31a0CCe3B526f;
-    address constant DVN = 0x6788f52439ACA6BFF597d3eeC2DC9a44B8FEE842;
-    address constant TREASURY = 0x4514FC667a944752ee8A29F544c1B20b1A315f25;
-    uint32 constant EID = 30280;
+contract DeployRemoteHopSei is DeployRemoteHop {
+    constructor() {
+        EXECUTOR = 0xc097ab8CD7b053326DFe9fB3E3a31a0CCe3B526f;
+        DVN = 0x6788f52439ACA6BFF597d3eeC2DC9a44B8FEE842;
+        TREASURY = 0x4514FC667a944752ee8A29F544c1B20b1A315f25;
+        EID = 30280;
 
-    function run() public broadcaster {
-        RemoteHop remoteHop = new RemoteHop(bytes32(uint256(uint160(FRAXTAL_HOP))), 2, EXECUTOR, DVN, TREASURY);
-        console.log("RemoteHop deployed at:", address(remoteHop));
-
-        RemoteMintRedeemHop remoteMintRedeemHop = new RemoteMintRedeemHop(
-            bytes32(uint256(uint160(FRAXTAL_MINTREDEEM_HOP))),
-            2,
-            EXECUTOR,
-            DVN,
-            TREASURY,
-            EID
-        );
-        console.log("RemoteMintRedeemHop deployed at:", address(remoteMintRedeemHop));
+        frxUsdOft = 0x80Eede496655FB9047dd39d9f418d5483ED600df;
+        sfrxUsdOft = 0x5Bff88cA1442c2496f7E475E9e7786383Bc070c0;
+        frxEthOft = 0x43eDD7f3831b08FE70B7555ddD373C8bF65a9050;
+        sfrxEthOft = 0x3Ec3849C33291a9eF4c5dB86De593EB4A37fDe45;
+        fxsOft = 0x64445f0aecC51E94aD52d8AC56b7190e764E561a;
+        fpiOft = 0x90581eCa9469D8D7F5D3B60f4715027aDFCf7927;
     }
 }

--- a/src/script/hop/Remote/DeployRemoteHopSonic.sol
+++ b/src/script/hop/Remote/DeployRemoteHopSonic.sol
@@ -1,32 +1,20 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
-import { BaseScript } from "frax-std/BaseScript.sol";
-import { console } from "frax-std/BaseScript.sol";
-import { RemoteHop } from "src/contracts/hop/RemoteHop.sol";
-import { RemoteMintRedeemHop } from "src/contracts/hop/RemoteMintRedeemHop.sol";
-import "src/Constants.sol" as Constants;
+import { DeployRemoteHop } from "./DeployRemoteHop.sol";
 
-contract DeployRemoteHopSonic is BaseScript {
-    address constant FRAXTAL_HOP = 0xEE30e79b54e9a341dcD5621AF1799e2af799b9B0;
-    address constant FRAXTAL_MINTREDEEM_HOP = 0xf8b29272Db8B482459596C60b37BBF0B8F86E892;
-    address constant EXECUTOR = 0x4208D6E27538189bB48E603D6123A94b8Abe0A0b;
-    address constant DVN = 0x282b3386571f7f794450d5789911a9804FA346b4;
-    address constant TREASURY = 0x4514FC667a944752ee8A29F544c1B20b1A315f25;
-    uint32 constant EID = 30332;
+contract DeployRemoteHopSonic is DeployRemoteHop {
+    constructor() {
+        EXECUTOR = 0x4208D6E27538189bB48E603D6123A94b8Abe0A0b;
+        DVN = 0x282b3386571f7f794450d5789911a9804FA346b4;
+        TREASURY = 0x4514FC667a944752ee8A29F544c1B20b1A315f25;
+        EID = 30332;
 
-    function run() public broadcaster {
-        RemoteHop remoteHop = new RemoteHop(bytes32(uint256(uint160(FRAXTAL_HOP))), 2, EXECUTOR, DVN, TREASURY);
-        console.log("RemoteHop deployed at:", address(remoteHop));
-
-        RemoteMintRedeemHop remoteMintRedeemHop = new RemoteMintRedeemHop(
-            bytes32(uint256(uint160(FRAXTAL_MINTREDEEM_HOP))),
-            2,
-            EXECUTOR,
-            DVN,
-            TREASURY,
-            EID
-        );
-        console.log("RemoteMintRedeemHop deployed at:", address(remoteMintRedeemHop));
+        frxUsdOft = 0x80Eede496655FB9047dd39d9f418d5483ED600df;
+        sfrxUsdOft = 0x5Bff88cA1442c2496f7E475E9e7786383Bc070c0;
+        frxEthOft = 0x43eDD7f3831b08FE70B7555ddD373C8bF65a9050;
+        sfrxEthOft = 0x3Ec3849C33291a9eF4c5dB86De593EB4A37fDe45;
+        fxsOft = 0x64445f0aecC51E94aD52d8AC56b7190e764E561a;
+        fpiOft = 0x90581eCa9469D8D7F5D3B60f4715027aDFCf7927;
     }
 }

--- a/src/test/hop/FraxtalHopTest.sol
+++ b/src/test/hop/FraxtalHopTest.sol
@@ -24,7 +24,21 @@ contract FraxtalHopTest is BaseTest {
     function setUpFraxtal() public virtual {
         vm.createSelectFork(vm.envString("FRAXTAL_MAINNET_URL"), 17180177);
         hop = new FraxtalHop();
-        remoteHop = new RemoteHop(OFTMsgCodec.addressToBytes32(address(hop)), 2, EXECUTOR, DVN, TREASURY);
+        remoteHop = new RemoteHop(
+            OFTMsgCodec.addressToBytes32(address(hop)),
+            2,
+            EXECUTOR,
+            DVN,
+            TREASURY,
+            RemoteHop.ApprovedOFTs({
+                frxUsd: 0x96A394058E2b84A89bac9667B19661Ed003cF5D4,
+                sfrxUsd: 0x88Aa7854D3b2dAA5e37E7Ce73A1F39669623a361,
+                frxEth: 0x9aBFE1F8a999B0011ecD6116649AEe8D575F5604,
+                sfrxEth: 0x999dfAbe3b1cc2EF66eB032Eea42FeA329bBa168,
+                fxs: 0xd86fBBd0c8715d2C1f40e451e5C3514e65E7576A,
+                fpi: 0x75c38D46001b0F8108c4136216bd2694982C20FC
+            })
+        );
         hop.setRemoteHop(30110, address(remoteHop));
         remoteHop.setFraxtalHop(address(hop));
         payable(address(hop)).transfer(1 ether);
@@ -38,7 +52,15 @@ contract FraxtalHopTest is BaseTest {
             2,
             0x31CAe3B7fB82d847621859fb1585353c5720660D,
             0x2f55C492897526677C5B68fb199ea31E2c126416,
-            0x532410B245eB41f24Ed1179BA0f6ffD94738AE70
+            0x532410B245eB41f24Ed1179BA0f6ffD94738AE70,
+            RemoteHop.ApprovedOFTs({
+                frxUsd: 0x96A394058E2b84A89bac9667B19661Ed003cF5D4,
+                sfrxUsd: 0x88Aa7854D3b2dAA5e37E7Ce73A1F39669623a361,
+                frxEth: 0x9aBFE1F8a999B0011ecD6116649AEe8D575F5604,
+                sfrxEth: 0x999dfAbe3b1cc2EF66eB032Eea42FeA329bBa168,
+                fxs: 0xd86fBBd0c8715d2C1f40e451e5C3514e65E7576A,
+                fpi: 0x75c38D46001b0F8108c4136216bd2694982C20FC
+            })
         );
     }
 
@@ -50,7 +72,15 @@ contract FraxtalHopTest is BaseTest {
             2,
             0x173272739Bd7Aa6e4e214714048a9fE699453059,
             0x589dEDbD617e0CBcB916A9223F4d1300c294236b,
-            0x5ebB3f2feaA15271101a927869B3A56837e73056
+            0x5ebB3f2feaA15271101a927869B3A56837e73056,
+            RemoteHop.ApprovedOFTs({
+                frxUsd: 0x96A394058E2b84A89bac9667B19661Ed003cF5D4,
+                sfrxUsd: 0x88Aa7854D3b2dAA5e37E7Ce73A1F39669623a361,
+                frxEth: 0x9aBFE1F8a999B0011ecD6116649AEe8D575F5604,
+                sfrxEth: 0x999dfAbe3b1cc2EF66eB032Eea42FeA329bBa168,
+                fxs: 0xd86fBBd0c8715d2C1f40e451e5C3514e65E7576A,
+                fpi: 0x75c38D46001b0F8108c4136216bd2694982C20FC
+            })
         );
     }
 

--- a/src/test/hop/FraxtalMintRedeemHopTest.sol
+++ b/src/test/hop/FraxtalMintRedeemHopTest.sol
@@ -30,7 +30,9 @@ contract FraxtalMintRedeemHopTest2 is BaseTest {
             EXECUTOR,
             DVN,
             TREASURY,
-            30255
+            30255,
+            0x96A394058E2b84A89bac9667B19661Ed003cF5D4, // frxUsdOft
+            0x88Aa7854D3b2dAA5e37E7Ce73A1F39669623a361 // sfrxUsdOft
         );
         hop.setRemoteHop(30110, address(remoteHop));
         remoteHop.setFraxtalHop(address(hop));
@@ -46,7 +48,9 @@ contract FraxtalMintRedeemHopTest2 is BaseTest {
             0x31CAe3B7fB82d847621859fb1585353c5720660D,
             0x2f55C492897526677C5B68fb199ea31E2c126416,
             0x532410B245eB41f24Ed1179BA0f6ffD94738AE70,
-            30110
+            30110,
+            0x80Eede496655FB9047dd39d9f418d5483ED600df, // frxUsdOft
+            0x5Bff88cA1442c2496f7E475E9e7786383Bc070c0 // sfrxUsdOft
         );
     }
 
@@ -59,7 +63,9 @@ contract FraxtalMintRedeemHopTest2 is BaseTest {
             0x173272739Bd7Aa6e4e214714048a9fE699453059,
             0x589dEDbD617e0CBcB916A9223F4d1300c294236b,
             0x5ebB3f2feaA15271101a927869B3A56837e73056,
-            30101
+            30101,
+            0x566a6442A5A6e9895B9dCA97cC7879D632c6e4B0, // frxUsdOft
+            0x7311CEA93ccf5f4F7b789eE31eBA5D9B9290E126 // sfrxUsdOft
         );
     }
 


### PR DESCRIPTION
Adds a requirement on both the Remote and Fraxtal hop side that the OFT sent is approved.

This fix prevents malicious OFTs from draining the hop contracts.