### PR TITLE
fix: require fee in msg on send to fraxtal

### DIFF
--- a/src/contracts/hop/RemoteHop.sol
+++ b/src/contracts/hop/RemoteHop.sol
@@ -121,6 +121,7 @@ contract RemoteHop is Ownable2Step {
         IOFT(_oft).send{ value: fee.nativeFee }(sendParam, fee, address(this));
 
         // Refund the excess
+        if (msg.value < fee.nativeFee) revert InsufficientFee();
         if (msg.value > fee.nativeFee) payable(msg.sender).transfer(msg.value - fee.nativeFee);
     }
 


### PR DESCRIPTION
Prevents callers from sending to fraxtal without providing the expected native fee.