### PR TITLE
refactor: owner in RemoteHop constructor

### DIFF
--- a/src/contracts/hop/RemoteHop.sol
+++ b/src/contracts/hop/RemoteHop.sol
@@ -44,14 +44,19 @@ contract RemoteHop is Ownable2Step {
     error RefundFailed();
     error ZeroAmountSend();
 
+    function version() external pure virtual returns (string memory) {
+        return "1.0.1";
+    }
+
     constructor(
+        address _owner,
         bytes32 _fraxtalHop,
         uint256 _numDVNs,
         address _EXECUTOR,
         address _DVN,
         address _TREASURY,
         address[] memory _approvedOfts
-    ) Ownable(msg.sender) {
+    ) Ownable(_owner) {
         fraxtalHop = _fraxtalHop;
         numDVNs = _numDVNs;
         EXECUTOR = _EXECUTOR;

--- a/src/contracts/hop/RemoteMintRedeemHop.sol
+++ b/src/contracts/hop/RemoteMintRedeemHop.sol
@@ -45,7 +45,12 @@ contract RemoteMintRedeemHop is Ownable2Step {
     error RefundFailed();
     error ZeroAmountSend();
 
+    function version() external pure virtual returns (string memory) {
+        return "1.0.1";
+    }
+
     constructor(
+        address _owner,
         bytes32 _fraxtalHop,
         uint256 _numDVNs,
         address _EXECUTOR,
@@ -54,7 +59,7 @@ contract RemoteMintRedeemHop is Ownable2Step {
         uint32 _EID,
         address _frxUsdOft,
         address _sfrxUsdOft
-    ) Ownable(msg.sender) {
+    ) Ownable(_owner) {
         fraxtalHop = _fraxtalHop;
         numDVNs = _numDVNs;
         EXECUTOR = _EXECUTOR;

--- a/src/contracts/hop/TestnetRemoteHop.sol
+++ b/src/contracts/hop/TestnetRemoteHop.sol
@@ -44,14 +44,19 @@ contract TestnetRemoteHop is Ownable2Step {
     error RefundFailed();
     error ZeroAmountSend();
 
+    function version() external pure virtual returns (string memory) {
+        return "1.0.1";
+    }
+
     constructor(
+        address _owner,
         bytes32 _fraxtalHop,
         uint256 _numDVNs,
         address _EXECUTOR,
         address _DVN,
         address _TREASURY,
         address[] memory _approvedOfts
-    ) Ownable(msg.sender) {
+    ) Ownable(_owner) {
         fraxtalHop = _fraxtalHop;
         numDVNs = _numDVNs;
         EXECUTOR = _EXECUTOR;

--- a/src/script/hop/Remote/DeployRemoteHop.sol
+++ b/src/script/hop/Remote/DeployRemoteHop.sol
@@ -25,6 +25,8 @@ abstract contract DeployRemoteHop is BaseScript {
     address constant FRAXTAL_HOP = 0x2A2019b30C157dB6c1C01306b8025167dBe1803B;
     address constant FRAXTAL_MINTREDEEM_HOP = 0x3e6a2cBaFD864e09e6DAb9Cf035a0AbEa32bc0BC;
 
+    address owner;
+
     address EXECUTOR;
     address DVN;
     address SEND_LIBRARY;
@@ -48,6 +50,7 @@ abstract contract DeployRemoteHop is BaseScript {
         approvedOfts.push(fpiOft);
 
         RemoteHop remoteHop = new RemoteHop({
+            _owner: owner,
             _fraxtalHop: bytes32(uint256(uint160(FRAXTAL_HOP))),
             _numDVNs: 3,
             _EXECUTOR: EXECUTOR,
@@ -58,6 +61,7 @@ abstract contract DeployRemoteHop is BaseScript {
         console.log("RemoteHop deployed at:", address(remoteHop));
 
         RemoteMintRedeemHop remoteMintRedeemHop = new RemoteMintRedeemHop({
+            _owner: owner,
             _fraxtalHop: bytes32(uint256(uint160(FRAXTAL_MINTREDEEM_HOP))),
             _numDVNs: 3,
             _EXECUTOR: EXECUTOR,

--- a/src/script/hop/Remote/DeployTestnetRemoteHop.sol
+++ b/src/script/hop/Remote/DeployTestnetRemoteHop.sol
@@ -7,6 +7,8 @@ import { TestnetRemoteHop } from "src/contracts/hop/TestnetRemoteHop.sol";
 abstract contract DeployTestnetRemoteHop is BaseScript {
     address constant FRAXTAL_HOP = 0xd593Df4E2E3156C5707bB6AE4ba26fd4A9A04586;
 
+    address owner;
+
     address EXECUTOR;
     address DVN;
     address TREASURY;
@@ -18,6 +20,7 @@ abstract contract DeployTestnetRemoteHop is BaseScript {
         approvedOfts.push(frxUsdOft);
 
         TestnetRemoteHop remoteHop = new TestnetRemoteHop({
+            _owner: owner,
             _fraxtalHop: bytes32(uint256(uint160(FRAXTAL_HOP))),
             _numDVNs: 2,
             _EXECUTOR: EXECUTOR,

--- a/src/test/hop/FraxtalHopTest.sol
+++ b/src/test/hop/FraxtalHopTest.sol
@@ -32,7 +32,7 @@ contract FraxtalHopTest is BaseTest {
 
         vm.createSelectFork(vm.envString("FRAXTAL_MAINNET_URL"), 17180177);
         hop = new FraxtalHop(approvedOfts);
-        remoteHop = new RemoteHop(OFTMsgCodec.addressToBytes32(address(hop)), 2, EXECUTOR, DVN, TREASURY, approvedOfts);
+        remoteHop = new RemoteHop(address(1), OFTMsgCodec.addressToBytes32(address(hop)), 2, EXECUTOR, DVN, TREASURY, approvedOfts);
         hop.setRemoteHop(30110, address(remoteHop));
         remoteHop.setFraxtalHop(address(hop));
         payable(address(hop)).call{ value: 1 ether }("");
@@ -49,6 +49,7 @@ contract FraxtalHopTest is BaseTest {
         vm.createSelectFork(vm.envString("ARBITRUM_MAINNET_URL"), 316670752);
         hop = new FraxtalHop(approvedOfts);
         remoteHop = new RemoteHop(
+            address(1), // owner
             OFTMsgCodec.addressToBytes32(address(hop)),
             2,
             0x31CAe3B7fB82d847621859fb1585353c5720660D,
@@ -69,6 +70,7 @@ contract FraxtalHopTest is BaseTest {
         vm.createSelectFork(vm.envString("ETHEREUM_MAINNET_URL"), 22124047);
         hop = new FraxtalHop(approvedOfts);
         remoteHop = new RemoteHop(
+            address(1), // owner
             OFTMsgCodec.addressToBytes32(address(hop)),
             2,
             0x173272739Bd7Aa6e4e214714048a9fE699453059,

--- a/src/test/hop/FraxtalMintRedeemHopTest.sol
+++ b/src/test/hop/FraxtalMintRedeemHopTest.sol
@@ -27,6 +27,7 @@ contract FraxtalMintRedeemHopTest2 is BaseTest {
         vm.createSelectFork(vm.envString("FRAXTAL_MAINNET_URL"), 17180177);
         hop = new FraxtalMintRedeemHop(frxUsdLockbox, sfrxUsdLockbox);
         remoteHop = new RemoteMintRedeemHop(
+            address(1),
             OFTMsgCodec.addressToBytes32(address(hop)),
             2,
             EXECUTOR,
@@ -45,6 +46,7 @@ contract FraxtalMintRedeemHopTest2 is BaseTest {
         vm.createSelectFork(vm.envString("ARBITRUM_MAINNET_URL"), 316670752);
         hop = new FraxtalMintRedeemHop(frxUsdLockbox, sfrxUsdLockbox);
         remoteHop = new RemoteMintRedeemHop(
+            address(1),
             OFTMsgCodec.addressToBytes32(address(hop)),
             2,
             0x31CAe3B7fB82d847621859fb1585353c5720660D,
@@ -60,6 +62,7 @@ contract FraxtalMintRedeemHopTest2 is BaseTest {
         vm.createSelectFork(vm.envString("ETHEREUM_MAINNET_URL"), 22124168);
         hop = new FraxtalMintRedeemHop(frxUsdLockbox, sfrxUsdLockbox);
         remoteHop = new RemoteMintRedeemHop(
+            address(1),
             OFTMsgCodec.addressToBytes32(address(hop)),
             2,
             0x173272739Bd7Aa6e4e214714048a9fE699453059,


### PR DESCRIPTION
Small refactor to set the owner address upon contract creation.  Previously, it was required to:
1. call `transferOwnership()` by the deployer
2. call `acceptTransferOwnership()` by the Frax team msig.

Now, ownership is automatically set and these two steps are no longer required.

Note that for future deployments, `owner` argument will need to be set in the local `DeployRemoteHopX.sol` script.  Otherwise the deployment will revert as you cannot initialize an Ownable contract with address(0), which is the current value as defined in the base deploy script.

@dhruvinparikh please approve.